### PR TITLE
Remove unused ComputeTarget import statement

### DIFF
--- a/01 - Get Started with Notebooks.ipynb
+++ b/01 - Get Started with Notebooks.ipynb
@@ -70,8 +70,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from azureml.core import ComputeTarget\n",
-    "\n",
     "print(\"Compute Resources:\")\n",
     "for compute_name in ws.compute_targets:\n",
     "    compute = ws.compute_targets[compute_name]\n",


### PR DESCRIPTION
Not sure why this is imported here since it isn't needed by the code that follows