### PR TITLE
Update 01-create-a-workspace.md

### DIFF
--- a/instructions/01-create-a-workspace.md
+++ b/instructions/01-create-a-workspace.md
@@ -69,7 +69,6 @@ A lot of data science and machine learning experimentation is performed by runni
 3. Enter the following commands to clone a Git repository containing notebooks, data, and other files to your workspace:
 
     ```bash
-    cd Users
     git clone https://github.com/MicrosoftLearning/mslearn-dp100
     ```
 


### PR DESCRIPTION
Removed "cd users" from the code section.
By default when you start the terminal you are at `~/cloudfiles/code/Users/username`