### PR TITLE
Update 15 - Detect Unfairness.ipynb

### DIFF
--- a/15 - Detect Unfairness.ipynb
+++ b/15 - Detect Unfairness.ipynb
@@ -46,7 +46,7 @@
     {
       "cell_type": "code",
       "source": [
-        "pip install --upgrade fairlearn==0.7.0 raiwidgets"
+        "pip install --upgrade fairlearn==0.7.0 raiwidgets  flask==2.1.3"
       ],
       "outputs": [],
       "execution_count": null,


### PR DESCRIPTION
fairnessdashboard TypeError: __init__() got an unexpected keyword argument 'unbound_message' error fix