### PR TITLE
[05 - Train Models] Add regularization rate to properties

### DIFF
--- a/05 - Train Models.ipynb
+++ b/05 - Train Models.ipynb
@@ -506,7 +506,7 @@
         "# Register the model\n",
         "run.register_model(model_path='outputs/diabetes_model.pkl', model_name='diabetes_model',\n",
         "                   tags={'Training context':'Parameterized script'},\n",
-        "                   properties={'AUC': run.get_metrics()['AUC'], 'Accuracy': run.get_metrics()['Accuracy']})\n",
+        "                   properties={'AUC': run.get_metrics()['AUC'], 'Accuracy': run.get_metrics()['Accuracy'], 'Regularization Rate': run.get_metrics()['Regularization Rate']})\n",
         "\n",
         "# List registered models\n",
         "for model in Model.list(ws):\n",


### PR DESCRIPTION
In the parameterized script, it makes sense to store the value of the regularization rate that has been used to train the model as a property of the model. This way it is easier later on to see which properties have been used to train the model.